### PR TITLE
adding automatic deps updates

### DIFF
--- a/.config/fish/fish_variables
+++ b/.config/fish/fish_variables
@@ -7,4 +7,4 @@ SETUVAR _fisher_jorgebucaran_2F_nvm_2E_fish_files:\x7e/\x2econfig/fish/functions
 SETUVAR _fisher_oh_2D_my_2D_fish_2F_theme_2D_bobthefish_files:\x7e/\x2econfig/fish/functions/__bobthefish_colors\x2efish\x1e\x7e/\x2econfig/fish/functions/__bobthefish_display_colors\x2efish\x1e\x7e/\x2econfig/fish/functions/__bobthefish_glyphs\x2efish\x1e\x7e/\x2econfig/fish/functions/bobthefish_display_colors\x2efish\x1e\x7e/\x2econfig/fish/functions/fish_greeting\x2efish\x1e\x7e/\x2econfig/fish/functions/fish_mode_prompt\x2efish\x1e\x7e/\x2econfig/fish/functions/fish_prompt\x2efish\x1e\x7e/\x2econfig/fish/functions/fish_right_prompt\x2efish\x1e\x7e/\x2econfig/fish/functions/fish_title\x2efish
 SETUVAR _fisher_plugins:jorgebucaran/fisher\x1ejorgebucaran/nvm\x2efish\x1eedc/bass\x1eoh\x2dmy\x2dfish/theme\x2dbobthefish
 SETUVAR _fisher_upgraded_to_4_4:\x1d
-SETUVAR fish_user_paths:/usr/local/go/bin
+SETUVAR fish_user_paths:/home/maknop/\x2elocal/bin\x1e/usr/local/go/bin

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,20 @@
+name: Auto-merge dependency PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/lua-lint.yml
+++ b/.github/workflows/lua-lint.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  luacheck:
+  lua-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-nvim-plugins.yml
+++ b/.github/workflows/update-nvim-plugins.yml
@@ -1,0 +1,46 @@
+name: Update Neovim Plugins
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Every Monday at 6am UTC
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Neovim
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: stable
+
+      - name: Update plugins
+        run: nvim --headless "+Lazy! update" +qa
+
+      - name: Create pull request
+        id: create-pr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update neovim plugins"
+          title: "chore: update neovim plugins"
+          body: |
+            Automated weekly update of Neovim plugins via lazy.nvim.
+
+            Changes are reflected in `.config/nvim/lazy-lock.json`.
+          branch: "auto/update-nvim-plugins"
+          delete-branch: true
+          labels: "dependencies"
+
+      - name: Enable auto-merge
+        if: steps.create-pr.outputs.pull-request-number != ''
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}


### PR DESCRIPTION
- `.github/dependabot.yml`: Runs weekly on Monday, bumps actions/checkout@v4 and any other pinned action versions across your workflows. PRs get a dependencies label.
- `.github/workflows/update-nvim-plugins.yml`: Runs headless Neovim every Monday at 6am UTC (`nvim --headless "+Lazy! update" +qa`), which updates lazy-lock.json to the latest commits on each plugin's tracked branch. If anything changed, opens a PR on auto/update-nvim-plugins and immediately enables auto-merge on it.
- `.github/workflows/auto-merge.yml`: Enables auto-merge on all Dependabot PRs as soon as they open, so they merge once the three lint checks pass.
