### PR TITLE
ci: fix update-nvim-plugins by setting XDG_CONFIG_HOME

### DIFF
--- a/.github/workflows/update-nvim-plugins.yml
+++ b/.github/workflows/update-nvim-plugins.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Update plugins
         run: nvim --headless "+Lazy! update" +qa
+        env:
+          XDG_CONFIG_HOME: ${{ github.workspace }}/.config
 
       - name: Create pull request
         id: create-pr


### PR DESCRIPTION
The following error was occurring in the `Update Plugins` Github Actions step: 
```
Run nvim --headless "+Lazy! update" +qa
  nvim --headless "+Lazy! update" +qa
  shell: /usr/bin/bash -e {0}
Error in command line:
E492: Not an editor command: Lazy! update
```

The fix is to set `XDG_CONFIG_HOME` so Neovim finds the config from the checked-out repo. This also ensures any lazy-lock.json changes land in the git working directory for the PR to capture.