### PR TITLE
nvim-treesitter newer versions do not have a configs module

### DIFF
--- a/.config/nvim/lua/config/lazy.lua
+++ b/.config/nvim/lua/config/lazy.lua
@@ -196,7 +196,7 @@ require("lazy").setup({
     build = ":TSUpdate",
     event = { "BufReadPost", "BufNewFile" },
     config = function()
-      require("nvim-treesitter.configs").setup({
+      require("nvim-treesitter").setup({
         ensure_installed = { "vim", "regex", "lua", "bash", "markdown", "markdown_inline" },
         highlight = {
           enable = true,


### PR DESCRIPTION
## Context
The `nvim-treesitter` plugin had an error regarding a configs module not being found. This made certain actions in Neovim fail like editing files and exiting Neovim.

## Fix
the installed version of nvim-treesitter no longer has a configs module (there's config.lua but no configs.lua). The new nvim-treesitter API changed from `require("nvim-treesitter.configs").setup()` to `require("nvim-treesitter").setup()`.